### PR TITLE
fix(nonce): mark signed nonce as occupied for pre-approval step

### DIFF
--- a/src/components/NewAction/NewActionSection.tsx
+++ b/src/components/NewAction/NewActionSection.tsx
@@ -1044,10 +1044,10 @@ export const NewActionSection = ({ onQueueCountChange }: NewActionSectionProps) 
             return updated;
           });
           setCurrentStepIndex(stepIndex + 1);
-          // Advance nonce so the next sign step (e.g. pre-approval) uses nonce + 1
-          setCurrentSafeNonce((prev) => prev + 1);
-          // Mark the signed nonce as occupied so calculateRecommendedNonce skips it
+          // Advance nonce and mark it as occupied so the next sign step
+          // (e.g. pre-approval) correctly uses nonce + 1
           if (nonce !== undefined) {
+            setCurrentSafeNonce((prev) => prev + 1);
             setQueueItems((prev) => [...prev, { nonce, approversCount: 1 } as QueueItem]);
           }
           // Notify that queue count may have changed

--- a/src/components/NewAction/NewActionSection.tsx
+++ b/src/components/NewAction/NewActionSection.tsx
@@ -1044,6 +1044,12 @@ export const NewActionSection = ({ onQueueCountChange }: NewActionSectionProps) 
             return updated;
           });
           setCurrentStepIndex(stepIndex + 1);
+          // Advance nonce so the next sign step (e.g. pre-approval) uses nonce + 1
+          setCurrentSafeNonce((prev) => prev + 1);
+          // Mark the signed nonce as occupied so calculateRecommendedNonce skips it
+          if (nonce !== undefined) {
+            setQueueItems((prev) => [...prev, { nonce, approversCount: 1 } as QueueItem]);
+          }
           // Notify that queue count may have changed
           onQueueCountChange?.();
         } else {


### PR DESCRIPTION
## Describe your changes

- fix nonce collision

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix nonce management to correctly increment and mark signed nonce as occupied during pre-approval step to prevent nonce conflicts in multi-step transactions.

Main changes:
- Added nonce increment logic after successful sign step to advance currentSafeNonce by 1
- Marked used nonce as occupied by adding it to queueItems with initial approver count
- Prevents next sign step from reusing same nonce by reserving it before pre-approval execution

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced nonce management following successful transaction signing operations to ensure accurate queue tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->