### PR TITLE
chore: hide simulate option

### DIFF
--- a/src/components/ActionDetailModal/index.tsx
+++ b/src/components/ActionDetailModal/index.tsx
@@ -3,7 +3,7 @@ import { Box, styled } from "@mui/material";
 import { ExternalLink as ShareIcon } from "lucide-react";
 import { XIcon } from "~/components/icons";
 import { CopyableText } from "~/components/shared/CopyButton";
-import { StyledTooltip } from "~/components/shared/StyledComponents";
+// import { StyledTooltip } from "~/components/shared/StyledComponents";
 import { getChainConfig, SupportedChainId } from "~/config/chains";
 import { canonHeaderTokens } from "~/config/themes/safeTheme";
 import { QueueItem } from "~/services";
@@ -147,12 +147,12 @@ export const ActionDetailModal = ({
               <TabLabel $isActive={activeTab === "details"}>DETAILS</TabLabel>
             </Tab>
             <TabDivider />
-            <StyledTooltip title='Transaction simulation coming soon' placement='top'>
+            {/* <StyledTooltip title='Transaction simulation coming soon' placement='top'>
               <TabDisabled>
                 <TabLabel $isActive={false}>SIMULATE</TabLabel>
               </TabDisabled>
-            </StyledTooltip>
-            <TabDivider />
+            </StyledTooltip> */}
+            {/* <TabDivider /> */}
             <TabSpacer />
             <ShareButton onClick={handleShare}>
               <TabLabel $isActive={false}>SHARE</TabLabel>
@@ -306,16 +306,16 @@ const Tab = styled("button", {
   },
 }));
 
-const TabDisabled = styled(Box)({
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  padding: "16px 20px",
-  backgroundColor: canonHeaderTokens.background.layer1,
-  cursor: "not-allowed",
-  opacity: 0.5,
-  flexShrink: 0,
-});
+// const TabDisabled = styled(Box)({
+//   display: "flex",
+//   alignItems: "center",
+//   justifyContent: "center",
+//   padding: "16px 20px",
+//   backgroundColor: canonHeaderTokens.background.layer1,
+//   cursor: "not-allowed",
+//   opacity: 0.5,
+//   flexShrink: 0,
+// });
 
 const TabLabel = styled("span", {
   shouldForwardProp: (prop) => prop !== "$isActive",


### PR DESCRIPTION
- temporarily hide simulate option
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove transaction simulation UI feature from ActionDetailModal component by commenting out related code and styling elements.

Main changes:
- Commented out StyledTooltip import and TabDisabled styled component definition
- Removed SIMULATE tab button and associated tooltip from modal tab bar
- Eliminated TabDivider component following the simulate tab to maintain proper UI spacing

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
