### PR TITLE
fix(signing): default to recommended nonce

### DIFF
--- a/src/components/NewAction/steps/SigningFlowStep.tsx
+++ b/src/components/NewAction/steps/SigningFlowStep.tsx
@@ -86,10 +86,10 @@ export const SigningFlowStep = ({
 
   // Update selected nonce when recommended nonce changes (e.g., after initial load)
   useEffect(() => {
-    if (!isNonceLocked && currentSafeNonce > 0) {
+    if (!isNonceLocked && nonceSelectionEnabled) {
       setSelectedNonce(recommendedNonce);
     }
-  }, [recommendedNonce, isNonceLocked, currentSafeNonce]);
+  }, [recommendedNonce, isNonceLocked, nonceSelectionEnabled]);
 
   // Navigation hook for completion buttons
   const navigateWithParams = useNavigateWithParams();


### PR DESCRIPTION
Fix nonce selection logic to properly default to recommended nonce when nonce selection is enabled, preventing incorrect nonce usage in signing flow.

Main changes:
- Replaced currentSafeNonce condition with nonceSelectionEnabled flag in useEffect to accurately control nonce updates
- Added nonceSelectionEnabled to dependency array for proper effect triggering on state changes
- Ensures selectedNonce updates to recommendedNonce only when nonce is unlocked and selection is enabled

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
