### PR TITLE
feat(chains): add Sepolia testnet support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,13 @@
 # Production RPC URLs (used in dev/production builds)
 VITE_RPC_ETHEREUM=https://eth-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
 VITE_RPC_OPTIMISM=https://opt-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
+VITE_RPC_SEPOLIA=https://eth-sepolia.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
 
 # Testing RPC URLs (used by Anvil for forking)
 # These should be reliable, high-rate-limit RPCs for fork testing
 RPC_URL_ETHEREUM=https://eth-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
 RPC_URL_OPTIMISM=https://mainnet.optimism.io
+RPC_URL_SEPOLIA=https://eth-sepolia.g.alchemy.com/v2/YOUR_ALCHEMY_KEY
 
 # Anvil Testing RPC (where the forked chain runs locally)
 RPC_URL_TESTING=http://127.0.0.1:8545

--- a/src/components/icons/ChainIcons.tsx
+++ b/src/components/icons/ChainIcons.tsx
@@ -47,12 +47,28 @@ interface ChainIconByIdProps extends ChainIconProps {
   chainId: SupportedChainId;
 }
 
+/**
+ * Sepolia Testnet Icon - Ethereum icon with a testnet indicator
+ */
+export const SepoliaIcon = ({ size = 14, className }: ChainIconProps) => (
+  <ChainIconImage
+    src={ethereumIcon}
+    alt='Sepolia'
+    width={size}
+    height={size}
+    className={className}
+    style={{ filter: "hue-rotate(200deg) saturate(0.7)" }}
+  />
+);
+
 export const ChainIcon = ({ chainId, size = 14, className }: ChainIconByIdProps) => {
   switch (chainId) {
     case SupportedChainId.ETHEREUM:
       return <EthereumIcon size={size} className={className} />;
     case SupportedChainId.OPTIMISM:
       return <OptimismIcon size={size} className={className} />;
+    case SupportedChainId.SEPOLIA:
+      return <SepoliaIcon size={size} className={className} />;
     default: {
       // Fallback to a colored circle based on chain config
       const config = getChainConfig(chainId);

--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -9,7 +9,7 @@
  */
 
 import { Chain } from "viem";
-import { mainnet, optimism } from "viem/chains";
+import { mainnet, optimism, sepolia } from "viem/chains";
 import { getEnv } from "./env";
 
 const { IS_PLAYWRIGHT } = getEnv();
@@ -21,6 +21,7 @@ const { IS_PLAYWRIGHT } = getEnv();
 export const TEST_RPC_URLS = {
   [optimism.id]: "http://127.0.0.1:8545",
   [mainnet.id]: "http://127.0.0.1:8546",
+  [sepolia.id]: "http://127.0.0.1:8547",
 } as const;
 
 /**
@@ -29,6 +30,7 @@ export const TEST_RPC_URLS = {
 export enum SupportedChainId {
   ETHEREUM = 1,
   OPTIMISM = 10,
+  SEPOLIA = 11155111,
 }
 
 /**
@@ -73,6 +75,15 @@ export const SUPPORTED_CHAINS: Record<SupportedChainId, ChainConfig> = {
     rpcUrl: IS_PLAYWRIGHT ? TEST_RPC_URLS[optimism.id] : getRpcUrl("VITE_RPC_OPTIMISM"),
     blockExplorerUrl: "https://optimistic.etherscan.io",
     iconColor: "#FF0420",
+  },
+  [SupportedChainId.SEPOLIA]: {
+    id: SupportedChainId.SEPOLIA,
+    name: "Sepolia Testnet",
+    shortName: "Sepolia",
+    chain: sepolia,
+    rpcUrl: IS_PLAYWRIGHT ? TEST_RPC_URLS[sepolia.id] : getRpcUrl("VITE_RPC_SEPOLIA"),
+    blockExplorerUrl: "https://sepolia.etherscan.io",
+    iconColor: "#6B8AFF",
   },
 };
 

--- a/src/config/e2eConnector.ts
+++ b/src/config/e2eConnector.ts
@@ -9,12 +9,12 @@ import {
   E2EProviderWithInternal,
 } from "@wonderland/walletless";
 import { createConnector } from "wagmi";
-import { mainnet, optimism } from "wagmi/chains";
+import { mainnet, optimism, sepolia } from "wagmi/chains";
 import { TEST_RPC_URLS } from "./chains";
 
 // Create an external provider so tests can control it via setSigningAccount
 export const e2eProvider = createE2EProvider({
-  chains: [mainnet, optimism],
+  chains: [mainnet, optimism, sepolia],
   rpcUrls: TEST_RPC_URLS,
 });
 

--- a/src/config/wagmiConfig.ts
+++ b/src/config/wagmiConfig.ts
@@ -1,7 +1,7 @@
 import { connectorsForWallets } from "@rainbow-me/rainbowkit";
 import { rainbowWallet, walletConnectWallet, injectedWallet } from "@rainbow-me/rainbowkit/wallets";
 import { createConfig, http, cookieStorage, createStorage } from "wagmi";
-import { mainnet, optimism } from "wagmi/chains";
+import { mainnet, optimism, sepolia } from "wagmi/chains";
 import { getConfig } from "~/config";
 import { SUPPORTED_CHAINS, SupportedChainId } from "~/config/chains";
 import { e2eWallet } from "./e2eConnector";
@@ -34,7 +34,7 @@ const connectors = connectorsForWallets(
 );
 
 export const config = createConfig({
-  chains: [mainnet, optimism],
+  chains: [mainnet, optimism, sepolia],
   ssr: false, // Client-side only app
   storage: createStorage({
     storage: cookieStorage,
@@ -42,6 +42,7 @@ export const config = createConfig({
   transports: {
     [mainnet.id]: http(SUPPORTED_CHAINS[SupportedChainId.ETHEREUM].rpcUrl),
     [optimism.id]: http(SUPPORTED_CHAINS[SupportedChainId.OPTIMISM].rpcUrl),
+    [sepolia.id]: http(SUPPORTED_CHAINS[SupportedChainId.SEPOLIA].rpcUrl),
   },
   batch: { multicall: true },
   connectors,

--- a/src/constants/tokenList.ts
+++ b/src/constants/tokenList.ts
@@ -2960,8 +2960,38 @@ const OPTIMISM_TOKENS: TokenInfo[] = [
   },
 ];
 
+const SEPOLIA_TOKENS: TokenInfo[] = [
+  {
+    chainId: 11155111,
+    address: "0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9" as Address,
+    name: "Wrapped Ether",
+    symbol: "WETH",
+    decimals: 18,
+    logoURI:
+      "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+  },
+  {
+    chainId: 11155111,
+    address: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238" as Address,
+    name: "USDCoin",
+    symbol: "USDC",
+    decimals: 6,
+    logoURI:
+      "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+  },
+  {
+    chainId: 11155111,
+    address: "0xaA8E23Fb1079EA71e0a56F48a2aA51851D8433D0" as Address,
+    name: "Tether USD",
+    symbol: "USDT",
+    decimals: 6,
+    logoURI:
+      "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+  },
+];
+
 /** Combined token list for all supported chains */
-export const TOKEN_LIST: TokenInfo[] = [...ETHEREUM_TOKENS, ...OPTIMISM_TOKENS];
+export const TOKEN_LIST: TokenInfo[] = [...ETHEREUM_TOKENS, ...OPTIMISM_TOKENS, ...SEPOLIA_TOKENS];
 
 /** Get tokens filtered by chain ID */
 export const getTokensByChainId = (chainId: number): TokenInfo[] => {


### PR DESCRIPTION
## Summary

- Adds `SEPOLIA` (chain ID `11155111`) to the `SupportedChainId` enum and `SUPPORTED_CHAINS` config with block explorer at `https://sepolia.etherscan.io`
- Imports `sepolia` from `viem/chains` and `wagmi/chains` in all chain-aware configs (`chains.ts`, `wagmiConfig.ts`, `e2eConnector.ts`)
- Adds Sepolia transport to the wagmi config and includes it in the e2e test provider chains
- Adds a `SepoliaIcon` component (Ethereum icon with a blue hue shift to visually distinguish testnet) and wires it into the `ChainIcon` switch
- Adds a minimal Sepolia token list (WETH, USDC, USDT at their well-known Sepolia addresses)
- Adds `VITE_RPC_SEPOLIA` and `RPC_URL_SEPOLIA` entries to `.env.example`

## Test plan

- [ ] Connect a wallet on Sepolia — the network should appear in the chain selector
- [ ] Verify the Sepolia icon renders distinctly (blue-tinted Ethereum logo)
- [ ] Verify the token selector on Sepolia shows WETH, USDC, USDT
- [ ] Verify Ethereum and Optimism behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>